### PR TITLE
Improved End of Queue Matching

### DIFF
--- a/gearman_overview/gearman_overview.rb
+++ b/gearman_overview/gearman_overview.rb
@@ -11,7 +11,7 @@ class GearmanOverview < Scout::Plugin
   EOS
   def build_report
     telnet = Net::Telnet::new("Host" => option(:host), "Port" => option(:port))
-    status = telnet.cmd("String" => "status", "Match" => /\n./)
+    status = telnet.cmd("String" => "status", "Match" => /^.\n/)
     counts = { :jobs => 0, :running => 0, :workers => 0}
     status.split("\n")[0...-1].map do |job|
       task, jobs, running, workers = job.split("\t")


### PR DESCRIPTION
Original string match failed when the queue is empty, which caused plugin to timeout, which caused Scout to report plugin failure.  Proposed syntax matches even when there are no jobs in queue (i.e. on gearmand start).
